### PR TITLE
Bug: SOE is slow after refactoring

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     name: ${{ matrix.platform }} ${{ matrix.python-version }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest]
         python-version: [3.8]
         include:
           - platform: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7]
+        python-version: [3.8]
         include:
           - platform: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please try the [Examples](https://cblearn.readthedocs.io/en/latest/generated_exa
 
 ## Getting Started
 
-cblearn required Python 3.7 or newer. The easiest way to install is using `pip`:
+cblearn required Python 3.8 or newer. The easiest way to install is using `pip`:
 
 ```
 pip install https://github.com/dekuenstle/cblearn.git

--- a/cblearn/datasets/_imagenet_similarity.py
+++ b/cblearn/datasets/_imagenet_similarity.py
@@ -136,7 +136,7 @@ def fetch_imagenet_similarity(data_home: Optional[os.PathLike] = None, download_
     data.pop('trial_type')
     catalog['class_map_label'] = catalog['class_map_label'].astype(str)
     catalog['stimulus_filepath'] = catalog['stimulus_filepath'].astype(str)
-    
+
     if shuffle:
         random_state = check_random_state(random_state)
         ix = random_state.permutation(len(data['stimulus_set']))

--- a/cblearn/embedding/_soe.py
+++ b/cblearn/embedding/_soe.py
@@ -181,7 +181,7 @@ def _soe_loss(x, x_shape, quadruplet, margin):
     """ Loss equation (1) of Terada & Luxburg (2014)
      and Gradient of the loss function.
      """
-    ### OBJECTIVE ###
+    # OBJECTIVE #
     X = x.reshape(x_shape)
     X_dist = distance_matrix(X, X)
     ij_dist = X_dist[quadruplet[:, 0], quadruplet[:, 1]]
@@ -189,7 +189,7 @@ def _soe_loss(x, x_shape, quadruplet, margin):
     differences = ij_dist + margin - kl_dist
     stress = (np.maximum(differences, 0) ** 2)
 
-    ### GRADIENT ###delta_time =
+    # GRADIENT #
     is_diff_positive = differences > 0  # Case 1, 2.1.1
     ij_dist_valid = np.maximum(ij_dist[is_diff_positive, np.newaxis], 0.0000001)
     kl_dist_valid = np.maximum(kl_dist[is_diff_positive, np.newaxis], 0.0000001)

--- a/cblearn/embedding/_soe.py
+++ b/cblearn/embedding/_soe.py
@@ -19,6 +19,10 @@ class SOE(BaseEstimator, TripletEmbeddingMixin):
         This estimator supports multiple implementations which can be selected by the `backend` parameter.
         The majorizing backend for SOE is described in the paper original paper.
 
+        This class restarts the optimizition from multiple random initializations to increase the probability of
+        good results in low-dimensional embeddings. This behaviour multiplies computation time when fitting
+        the embeding but can be disabled by `SOE(n_components, n_init=1)`.
+
         The *torch* backend uses the ADAM optimizer and backpropagation [2]_.
         It can executed on CPU, but also CUDA GPUs.
 

--- a/cblearn/embedding/_ste.py
+++ b/cblearn/embedding/_ste.py
@@ -202,4 +202,4 @@ class TSTE(STE):
                  backend: str = "scipy", learning_rate=1, batch_size=50_000,  device: str = "auto"):
         heavy_tailed = True
         return super().__init__(n_components, heavy_tailed, verbose, random_state, max_iter, backend,
-                                         learning_rate, batch_size, device)
+                                learning_rate, batch_size, device)

--- a/cblearn/embedding/tests/test_sklearn_estimator_checks.py
+++ b/cblearn/embedding/tests/test_sklearn_estimator_checks.py
@@ -18,13 +18,13 @@ import pytest
 import numpy as np
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
-from cblearn.embedding import SOE
+from cblearn.embedding import SOE, MLDS, STE, TSTE, CKL, GNMDS
 from cblearn.embedding import wrapper
 from cblearn.datasets import make_random_triplets
 
 
 # Add new estimators here:
-ALL_TRIPLET_EMBEDDING_ESTIMATORS = [SOE(), wrapper.SOE(), wrapper.MLDS()]
+ALL_TRIPLET_EMBEDDING_ESTIMATORS = [SOE(), MLDS(), STE(), TSTE(), CKL(), GNMDS()]
 
 
 def _features_to_triplets(X):

--- a/cblearn/embedding/tests/test_soe.py
+++ b/cblearn/embedding/tests/test_soe.py
@@ -29,7 +29,6 @@ def test_soe_repeat():
     assert stat.pvalue < 0.05
 
 
-
 @pytest.mark.parametrize('n,d', [(20, 1), (50, 2), (100, 3)])
 def test_soe_gradient(n, d):
     """ Test the gradient of the SOE loss function by comparing with local loss differences. """

--- a/cblearn/embedding/tests/test_soe.py
+++ b/cblearn/embedding/tests/test_soe.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from scipy.optimize import check_grad
+from scipy.stats import ttest_rel
 from cblearn.datasets import make_random_triplets
 
 from cblearn.embedding._soe import SOE, _soe_loss
@@ -10,24 +11,23 @@ def test_soe_repeat():
     """ Test that the repeated initialization leads to stable results. """
     n, d = 20, 1  # optimization is most unstable for d = 1
     X = np.random.randn(n, d)
-    T = make_random_triplets(X, size=2*d*n*np.log(n), result_format='list-order',
-                             noise='normal', noise_options=dict(scale=0.1))
-    T_test = make_random_triplets(X, size=10000, result_format='list-order',
-                             noise='normal', noise_options=dict(scale=0.1))
-    accuracy_threshold = 0.8  # empirically determined
-
-    # is this an unstable condition? Then single inititalization should sometimes have low accuracy.
-    with pytest.raises(AssertionError):
-        soe_one = SOE(n_components=d, n_init=1)
-        for _ in range(3):
-            soe_one.fit(T)
-            assert soe_one.score(T_test) > accuracy_threshold
 
     # does repeated initialization lead to stable results?
-    soe_repeat = SOE(n_components=d, n_init=10)
-    for _ in range(3):
-        stress = soe_repeat.fit(T).stress_
-        assert soe_repeat.score(T_test) > accuracy_threshold
+    score_one = []
+    score_repeat = []
+    for i in range(10):
+        T = make_random_triplets(X, size=2 * d * n * np.log(n), result_format='list-order',
+                                 noise='normal', noise_options=dict(scale=0.1))
+        T_test = make_random_triplets(X, size=10000, result_format='list-order',
+                                      noise='normal', noise_options=dict(scale=0.1))
+        soe_one = SOE(n_components=d, n_init=1)
+        soe_repeat = SOE(n_components=d, n_init=10)
+        score_one.append(soe_one.fit(T).score(T_test))
+        score_repeat.append(soe_repeat.fit(T).score(T_test))
+
+    stat = ttest_rel(score_one, score_repeat, alternative='less')
+    assert stat.pvalue < 0.05
+
 
 
 @pytest.mark.parametrize('n,d', [(20, 1), (50, 2), (100, 3)])

--- a/examples/small_embedding_benchmark.py
+++ b/examples/small_embedding_benchmark.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+r"""
+Small Ordinal Embedding Benchmark
+=================================
+
+In this example, we generate an artificial set of triplets to fit an ordinal embedding algorithm
+like SOE. We vary the data dimension and measure the average fit's duration and accuracy.
+"""
+
+import time
+
+import numpy as np
+
+from cblearn import embedding
+from cblearn.datasets import make_random_triplets
+
+
+def benchmark_embedding(embedding, n_dims):
+    estimator.n_components = n_dims
+    X = np.random.normal(size=(n_samples, n_dims))
+    T = make_random_triplets(X, size=n_triplets, result_format='list-order')
+    T_test = make_random_triplets(X, size=10_000, result_format='list-order')
+
+    delta_times = []
+    train_accs = []
+    test_accs = []
+    for _ in range(n_repeat):
+        start_time = time.time()
+        estimator.fit(T)
+        end_time = time.time()
+        delta_times.append(end_time - start_time)
+        train_accs.append(estimator.score(T))
+        test_accs.append(estimator.score(T_test))
+
+    print(f"{estimator}: time      {np.mean(delta_times):.2f} (sd: {np.std(delta_times):.2f})")
+    print(f"{estimator}: train acc {np.mean(train_accs):.2f} (sd: {np.std(train_accs):.2f})")
+    print(f"{estimator}: test  acc {np.mean(test_accs):.2f} (sd: {np.std(test_accs):.2f})")
+
+
+n_samples = 100
+n_triplets = 1_000
+n_repeat = 10
+estimator = embedding.SOE(1, n_init=1)
+
+print(f"samples={n_samples} triplets={n_triplets} benchmark-repetitions={n_repeat}")
+estimator = embedding.SOE(1, n_init=1)
+benchmark_embedding(estimator, n_dims=1)
+benchmark_embedding(estimator, n_dims=3)
+benchmark_embedding(estimator, n_dims=10)
+
+estimator = embedding.SOE(1, n_init=10)
+benchmark_embedding(estimator, n_dims=1)
+benchmark_embedding(estimator, n_dims=3)
+benchmark_embedding(estimator, n_dims=10)
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,14 +41,14 @@ install_requires =
 
 [options.extras_require]
 torch =
-    torch>=1.9,<2
+    torch~=1.11
 r_wrapper =
-    rpy2>=3.3,<4
+    rpy2~=3.5
 octave_wrapper =
-    oct2py>=5.2<6
+    oct2py~=5.5
 wrapper =
-    rpy2>=3.3,<4
-    oct2py>=5.2<6
+    rpy2~=3.5
+    oct2py~=5.5
 tests =
     pytest~=7.1
     pytest-cov~=3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,15 +26,15 @@ description_file = README.md
 license_files = LICENSE
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 zip_safe = False
 include_package_data = True
 install_requires =
-    numpy>=1.19,<2
-    scipy>=1.6,<2
-    scikit-learn>=0.23,<1
-    sparse>=0.11,<1
+    numpy~=1.22
+    scipy~=1.8
+    scikit-learn~=1.1
+    sparse~=0.13
 
 [options.package_data]
 * = cblearn/datasets/data/*.txt cblearn/datasets/descr/*.rst
@@ -50,13 +50,13 @@ wrapper =
     rpy2>=3.3,<4
     oct2py>=5.2<6
 tests =
-    pytest>=6,<7
-    pytest-cov>=2.10,<3
-    pytest-doctestplus>=0.9,<1
-    pytest-remotedata>=0.3,<1
-    flake8>=3.8,<4
-    mypy>=0.790
-    pandas>=1.1,<1.2
+    pytest~=7.1
+    pytest-cov~=3.0
+    pytest-doctestplus~=0.12
+    pytest-remotedata~=0.3
+    flake8~=4.0
+    mypy~=0.950
+    pandas~=1.4
 docs =
     sphinx~=4.5
     sphinx_rtd_theme~=1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,10 +58,10 @@ tests =
     mypy>=0.790
     pandas>=1.1,<1.2
 docs =
-    sphinx>=3.2,<4
-    sphinx_rtd_theme>=0.5,<1
-    sphinx-gallery>=0.8,<1
-    matplotlib>=3.3,<4
+    sphinx~=4.5
+    sphinx_rtd_theme~=1.0
+    sphinx-gallery~=0.10
+    matplotlib~=3.5
 
 
 [build_sphinx]


### PR DESCRIPTION
#46 noticed a severe slowdown of SOE, which is addressed in this PR: 

First, I investigated the slowdown:

I varied the loss (original quadruplet vs simplified triplet), the optimiser (original BFGS vs L-BFGS-B) and the dimensions and observed the embedding time and accuracy. The effect of the simplified loss is (surprisingly) small, thus, we 
keep a single loss for both triplets and quadruplets for better maintainability (less code is better code). 
However, both the dimension and the optimiser substantially affect both time and accuracy.
The L-BFGS-B was substantially faster and comparable accuracy; actually, all of the unexpected slow-down can be addressed with our change of optimiser. 
The repeated initialisations showed the expected 10x slow-down but also more accuracy of low-dimensional
embeddings. 

In conclusion, I will revert the optimiser change to L-BFGS-B but keep the repeated initialisations
and the simplification of the optimizer.
Thank you, @conzel, for investigating this regression. Could you please check if 
is this change sufficient for you?
  


L-BFGS-B
```
samples=100 triplets=1000 benchmark-repetitions=10
quadruplet-loss? False
SOE(n_components=1, n_init=1): time      0.04 (sd: 0.01)
SOE(n_components=1, n_init=1): train acc 0.87 (sd: 0.05)
SOE(n_components=1, n_init=1): test  acc 0.78 (sd: 0.08)
quadruplet-loss? False
SOE(n_components=3, n_init=1): time      0.06 (sd: 0.02)
SOE(n_components=3, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=3, n_init=1): test  acc 0.71 (sd: 0.03)
quadruplet-loss? False
SOE(n_components=10, n_init=1): time      0.02 (sd: 0.00)
SOE(n_components=10, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=10, n_init=1): test  acc 0.60 (sd: 0.01)
quadruplet-loss? True
SOE(n_components=1, n_init=1): time      0.04 (sd: 0.02)
SOE(n_components=1, n_init=1): train acc 0.92 (sd: 0.07)
SOE(n_components=1, n_init=1): test  acc 0.86 (sd: 0.09)
quadruplet-loss? True
SOE(n_components=3, n_init=1): time      0.07 (sd: 0.02)
SOE(n_components=3, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=3, n_init=1): test  acc 0.70 (sd: 0.02)
quadruplet-loss? True
SOE(n_components=10, n_init=1): time      0.02 (sd: 0.00)
SOE(n_components=10, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=10, n_init=1): test  acc 0.59 (sd: 0.01)

10 initializations:
quadruplet-loss? False
SOE(n_components=1): time      0.27 (sd: 0.03)
SOE(n_components=1): train acc 0.99 (sd: 0.01)
SOE(n_components=1): test  acc 0.93 (sd: 0.01)
quadruplet-loss? False
SOE(n_components=3): time      0.60 (sd: 0.04)
SOE(n_components=3): train acc 1.00 (sd: 0.00)
SOE(n_components=3): test  acc 0.70 (sd: 0.02)
quadruplet-loss? False
SOE(n_components=10): time      0.22 (sd: 0.03)
SOE(n_components=10): train acc 1.00 (sd: 0.00)
SOE(n_components=10): test  acc 0.60 (sd: 0.01)
```


BFGS:
```
samples=100 triplets=1000 benchmark-repetitions=10
quadruplet-loss? False
SOE(n_components=1, n_init=1): time      0.26 (sd: 0.09)
SOE(n_components=1, n_init=1): train acc 0.90 (sd: 0.08)
SOE(n_components=1, n_init=1): test  acc 0.83 (sd: 0.10)
quadruplet-loss? False
SOE(n_components=3, n_init=1): time      2.77 (sd: 0.58)
SOE(n_components=3, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=3, n_init=1): test  acc 0.70 (sd: 0.04)
quadruplet-loss? False
SOE(n_components=10, n_init=1): time      8.87 (sd: 1.31)
SOE(n_components=10, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=10, n_init=1): test  acc 0.61 (sd: 0.01)
quadruplet-loss? True
SOE(n_components=1, n_init=1): time      0.60 (sd: 0.14)
SOE(n_components=1, n_init=1): train acc 0.88 (sd: 0.07)
SOE(n_components=1, n_init=1): test  acc 0.80 (sd: 0.09)
quadruplet-loss? True
SOE(n_components=3, n_init=1): time      4.14 (sd: 0.63)
SOE(n_components=3, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=3, n_init=1): test  acc 0.69 (sd: 0.02)
quadruplet-loss? True
SOE(n_components=10, n_init=1): time      9.70 (sd: 0.65)
SOE(n_components=10, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=10, n_init=1): test  acc 0.61 (sd: 0.01)
```



For comparison: T-STE with L-BFGS-B
```
samples=100 triplets=1000 benchmark-repetitions=10
quadruplet-loss? False
SOE(n_components=1, n_init=1): time      0.29 (sd: 0.03)
SOE(n_components=1, n_init=1): train acc 0.88 (sd: 0.06)
SOE(n_components=1, n_init=1): test  acc 0.81 (sd: 0.09)
quadruplet-loss? False
SOE(n_components=3, n_init=1): time      3.18 (sd: 0.58)
SOE(n_components=3, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=3, n_init=1): test  acc 0.70 (sd: 0.03)
quadruplet-loss? False
SOE(n_components=10, n_init=1): time      8.22 (sd: 2.44)
SOE(n_components=10, n_init=1): train acc 1.00 (sd: 0.00)
SOE(n_components=10, n_init=1): test  acc 0.61 (sd: 0.01)
```